### PR TITLE
Make (symbol .)  insensitive to *print-case* by making sure argument to intern is upper case.

### DIFF
--- a/auxfns.lisp
+++ b/auxfns.lisp
@@ -215,7 +215,7 @@
 
 (defun symbol (&rest args)
   "Concatenate symbols or strings to form an interned symbol"
-  (intern (format nil "~{~a~}" args) "PAIPROLOG"))
+  (intern (format nil "~:@(~{~a~}~)" args) "PAIPROLOG"))
 
 (defun new-symbol (&rest args)
   "Concatenate symbols or strings to form an uninterned symbol"


### PR DESCRIPTION
If you do stuff with `*print-case*` as `:downcase`, symbols are read and their strings are upper-case, but symbols made with them land up being lower or mixed case.

```
paiprolog> (?- (bagof ?x (person ?x) ?res))
	       
; Compilation unit finished
;   The following functions were used but not defined:
;     |show-prolog-vars/2|
;     |bagof/3|
```